### PR TITLE
Fix overflow issues

### DIFF
--- a/deployConfigs/base.json
+++ b/deployConfigs/base.json
@@ -1,6 +1,6 @@
 {
     "name": "Base Deployment Config",
-    "tradeFee": "100000000000000000",
+    "tradeFee": "10",
     "aerodromeRouter": "0xcF77a3Ba9A5CA399B7c97c74d54e5b1Beb874E43",
     "platformFeeReceiver": "0x4ea8A5d400142e2498931f72f73a3100b3a65183",
     "marketCapThreshold": "100000000000000000000000",

--- a/src/launchbox/exchange/LaunchboxExchange.sol
+++ b/src/launchbox/exchange/LaunchboxExchange.sol
@@ -130,20 +130,14 @@ contract LaunchboxExchange {
         require(_tradeFee <= FEE_DENOMINATOR, "Trade fee must be less than or equal to 100%");
         require(reserveIn > 0 && reserveOut > 0, "Reserves must be greater than 0");
 
-        // Calculate fee
-        fee = mulDiv(amountIn, _tradeFee, FEE_DENOMINATOR);
-
-        // Calculate amountInWithFee
-        uint256 amountInWithFee = amountIn - fee;
-
-        // Calculate numerator and denominator
+        uint256 amountInWithFee = mulDiv(amountIn, (FEE_DENOMINATOR - _tradeFee), FEE_DENOMINATOR);
         uint256 numerator = mulDiv(amountInWithFee, reserveOut, 1);
         uint256 denominator = reserveIn * FEE_DENOMINATOR + amountInWithFee;
 
         require(denominator > 0, "Denominator must be greater than 0");
 
-        // Calculate amountOut
         amountOut = mulDiv(numerator, FEE_DENOMINATOR, denominator);
+        fee = amountIn - amountInWithFee;
 
         return (amountOut, fee);
     }

--- a/src/launchbox/exchange/LaunchboxExchange.sol
+++ b/src/launchbox/exchange/LaunchboxExchange.sol
@@ -4,13 +4,25 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IRouter} from "@aerodrome/contracts/contracts/interfaces/IRouter.sol";
 import {IPool} from "@aerodrome/contracts/contracts/interfaces/IPool.sol";
+import {console} from "forge-std/console.sol";
 
 contract LaunchboxExchange {
-    event ExchangeInitialized(address token, uint256 tradeFee, address feeReceiver, uint256 maxSupply);
+    event ExchangeInitialized(
+        address token,
+        uint256 tradeFee,
+        address feeReceiver,
+        uint256 maxSupply
+    );
     event TokenBuy(uint256 ethIn, uint256 tokenOut, uint256 fee, address buyer);
-    event TokenSell(uint256 tokenIn, uint256 ethOut, uint256 fee, address seller);
+    event TokenSell(
+        uint256 tokenIn,
+        uint256 ethOut,
+        uint256 fee,
+        address seller
+    );
 
-    IPool public constant WETH_USDC_PAIR = IPool(0xcDAC0d6c6C59727a65F871236188350531885C43);
+    IPool public constant WETH_USDC_PAIR =
+        IPool(0xcDAC0d6c6C59727a65F871236188350531885C43);
     uint256 public constant V_ETH_BALANCE = 1.5 ether;
     IERC20 public token;
     uint256 public maxSupply;
@@ -63,9 +75,16 @@ contract LaunchboxExchange {
         // assume whatever is in the exchange was meant to be sent to contract
         ethBalance = address(this).balance;
 
-        if (maxSupply < launchboxErc20Balance) revert MaxSupplyCannotBeLowerThanSuppliedTokens();
+        if (maxSupply < launchboxErc20Balance) {
+            revert MaxSupplyCannotBeLowerThanSuppliedTokens();
+        }
 
-        emit ExchangeInitialized(_tokenAddress, _tradeFee, _feeReceiver, _maxSupply);
+        emit ExchangeInitialized(
+            _tokenAddress,
+            _tradeFee,
+            _feeReceiver,
+            _maxSupply
+        );
     }
 
     function buyTokens() public payable {
@@ -115,36 +134,105 @@ contract LaunchboxExchange {
         emit BondingEnded(totalEth, totalTokens);
     }
 
-    function getAmountOutWithFee(uint256 amountIn, uint256 reserveIn, uint256 reserveOut, uint256 _tradeFee)
-        internal
-        pure
-        returns (uint256, uint256)
-    {
+    function getAmountOutWithFee(
+        uint256 amountIn,
+        uint256 reserveIn,
+        uint256 reserveOut,
+        uint256 _tradeFee
+    ) internal pure returns (uint256 amountOut, uint256 fee) {
         require(amountIn > 0, "Amount in must be greater than 0");
-        uint256 amountInWithFee = amountIn * (1000 - _tradeFee);
-        uint256 numerator = amountInWithFee * reserveOut;
-        uint256 denominator = (reserveIn * 1000) + amountInWithFee;
-        return (numerator / denominator, (amountIn * _tradeFee) / 1000);
+        require(
+            reserveIn > 0 && reserveOut > 0,
+            "Reserves must be greater than 0"
+        );
+
+        // Calculate fee
+        uint256 feeNumerator = mul(amountIn, _tradeFee);
+        fee = div(feeNumerator, 1000);
+
+        // Calculate amountInWithFee
+        uint256 amountInWithFee = sub(amountIn, fee);
+
+        // Calculate numerator
+        uint256 numerator = mul(amountInWithFee, reserveOut);
+
+        // Calculate denominator
+        uint256 reserveIn1000 = mul(reserveIn, 1000);
+        uint256 amountInWithFee1000 = mul(amountInWithFee, 1000);
+        uint256 denominator = add(
+            reserveIn1000,
+            div(amountInWithFee1000, amountIn)
+        );
+
+        require(denominator > 0, "Denominator must be greater than 0");
+
+        // Calculate amountOut
+        uint256 amountOut1000 = mul(numerator, 1000);
+        amountOut = div(amountOut1000, denominator);
+
+        return (amountOut, fee);
     }
 
-    function calculatePurchaseTokenOut(uint256 amountETHIn) public view returns (uint256, uint256) {
-        uint256 tokenSupply = launchboxErc20Balance;
-        return getAmountOutWithFee(amountETHIn, ethBalance + V_ETH_BALANCE, tokenSupply, tradeFee);
+    // SafeMath functions
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+        return c;
     }
 
-    function calculateSaleTokenOut(uint256 amountTokenIn) public view returns (uint256, uint256) {
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(b <= a, "SafeMath: subtraction overflow");
+        return a - b;
+    }
+
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        if (a == 0) return 0;
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+        return c;
+    }
+
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(b > 0, "SafeMath: division by zero");
+        return a / b;
+    }
+
+    function calculatePurchaseTokenOut(
+        uint256 amountETHIn
+    ) public view returns (uint256, uint256) {
         uint256 tokenSupply = launchboxErc20Balance;
-        return getAmountOutWithFee(amountTokenIn, tokenSupply, ethBalance + V_ETH_BALANCE, tradeFee);
+        return
+            getAmountOutWithFee(
+                amountETHIn,
+                ethBalance + V_ETH_BALANCE,
+                tokenSupply,
+                tradeFee
+            );
+    }
+
+    function calculateSaleTokenOut(
+        uint256 amountTokenIn
+    ) public view returns (uint256, uint256) {
+        uint256 tokenSupply = launchboxErc20Balance;
+        return
+            getAmountOutWithFee(
+                amountTokenIn,
+                tokenSupply,
+                ethBalance + V_ETH_BALANCE,
+                tradeFee
+            );
     }
 
     function _buy(uint256 ethAmount, address receiver) internal {
         // calculate tokens to mint and fee in eth
-        (uint256 tokensToMint, uint256 feeInEth) = calculatePurchaseTokenOut(ethAmount);
+        (uint256 tokensToMint, uint256 feeInEth) = calculatePurchaseTokenOut(
+            ethAmount
+        );
         if (tokensToMint > launchboxErc20Balance) {
             revert PurchaseExceedsSupply();
         }
         if (feeInEth > 0) {
-            (bool success,) = feeReceiver.call{value: feeInEth}("");
+            (bool success, ) = feeReceiver.call{value: feeInEth}("");
             if (!success) {
                 revert FeeTransferFailed();
             }
@@ -161,10 +249,15 @@ contract LaunchboxExchange {
 
     function _sell(uint256 tokenAmount, address receiver) internal {
         // calculate eth to refund and fee in token
-        (uint256 ethToReturn, uint256 feeInToken) = calculateSaleTokenOut(tokenAmount);
+        (uint256 ethToReturn, uint256 feeInToken) = calculateSaleTokenOut(
+            tokenAmount
+        );
         ethBalance -= ethToReturn;
         launchboxErc20Balance += (tokenAmount - feeInToken);
-        require(token.transferFrom(receiver, address(this), tokenAmount), "Transfer failed");
+        require(
+            token.transferFrom(receiver, address(this), tokenAmount),
+            "Transfer failed"
+        );
         if (feeInToken > 0) {
             token.transfer(feeReceiver, feeInToken);
         }
@@ -177,7 +270,9 @@ contract LaunchboxExchange {
     }
 
     function _calculateMarketCap() internal view returns (uint256) {
-        return maxSupply * ((_getSpotPrice()) * _getWETHPrice() / 10 ** 18) / 10 ** 18;
+        return
+            (maxSupply * (((_getSpotPrice()) * _getWETHPrice()) / 10 ** 18)) /
+            10 ** 18;
     }
 
     receive() external payable {
@@ -185,11 +280,12 @@ contract LaunchboxExchange {
     }
 
     function _getSpotPrice() internal view returns (uint256) {
-        return (ethBalance + 1.5 ether) * 10 ** 18 / launchboxErc20Balance;
+        return ((ethBalance + 1.5 ether) * 10 ** 18) / launchboxErc20Balance;
     }
 
     function _getWETHPrice() internal view returns (uint256) {
-        (uint256 _WETH_RESERVE, uint256 _USDC_RESERVE,) = WETH_USDC_PAIR.getReserves();
+        (uint256 _WETH_RESERVE, uint256 _USDC_RESERVE, ) = WETH_USDC_PAIR
+            .getReserves();
         uint256 price = (_USDC_RESERVE * 10 ** 12 * 10 ** 18) / _WETH_RESERVE;
         return price;
     }

--- a/src/launchbox/exchange/LaunchboxExchange.sol
+++ b/src/launchbox/exchange/LaunchboxExchange.sol
@@ -6,22 +6,16 @@ import {IRouter} from "@aerodrome/contracts/contracts/interfaces/IRouter.sol";
 import {IPool} from "@aerodrome/contracts/contracts/interfaces/IPool.sol";
 
 contract LaunchboxExchange {
-    event ExchangeInitialized(
-        address token,
-        uint256 tradeFee,
-        address feeReceiver,
-        uint256 maxSupply
-    );
+    event ExchangeInitialized(address token, uint256 tradeFee, address feeReceiver, uint256 maxSupply);
     event TokenBuy(uint256 ethIn, uint256 tokenOut, uint256 fee, address buyer);
-    event TokenSell(
-        uint256 tokenIn,
-        uint256 ethOut,
-        uint256 fee,
-        address seller
-    );
-    IPool public constant WETH_USDC_PAIR =
-        IPool(0xcDAC0d6c6C59727a65F871236188350531885C43);
+    event TokenSell(uint256 tokenIn, uint256 ethOut, uint256 fee, address seller);
+
+    IPool public constant WETH_USDC_PAIR = IPool(0xcDAC0d6c6C59727a65F871236188350531885C43);
     uint256 public constant V_ETH_BALANCE = 1.5 ether;
+    // Assume tradeFee is now represented in basis points (1/10000)
+    // 10000 = 100%, 5000 = 50%, 100 = 1%, 1 = 0.01%
+    uint256 public constant FEE_DENOMINATOR = 10_000;
+
     IERC20 public token;
     uint256 public maxSupply;
     uint256 public marketCapThreshold;
@@ -73,15 +67,11 @@ contract LaunchboxExchange {
         // assume whatever is in the exchange was meant to be sent to contract
         ethBalance = address(this).balance;
 
-        if (maxSupply < launchboxErc20Balance)
+        if (maxSupply < launchboxErc20Balance) {
             revert MaxSupplyCannotBeLowerThanSuppliedTokens();
+        }
 
-        emit ExchangeInitialized(
-            _tokenAddress,
-            _tradeFee,
-            _feeReceiver,
-            _maxSupply
-        );
+        emit ExchangeInitialized(_tokenAddress, _tradeFee, _feeReceiver, _maxSupply);
     }
 
     function buyTokens() public payable {
@@ -131,55 +121,105 @@ contract LaunchboxExchange {
         emit BondingEnded(totalEth, totalTokens);
     }
 
-    function getAmountOutWithFee(
-        uint256 amountIn,
-        uint256 reserveIn,
-        uint256 reserveOut,
-        uint256 _tradeFee
-    ) internal pure returns (uint256, uint256) {
+    function getAmountOutWithFee(uint256 amountIn, uint256 reserveIn, uint256 reserveOut, uint256 _tradeFee)
+        internal
+        pure
+        returns (uint256 amountOut, uint256 fee)
+    {
         require(amountIn > 0, "Amount in must be greater than 0");
-        uint256 amountInWithFee = amountIn * (1000 - _tradeFee);
-        uint256 numerator = amountInWithFee * reserveOut;
-        uint256 denominator = (reserveIn * 1000) + amountInWithFee;
-        return (numerator / denominator, (amountIn * _tradeFee) / 1000);
+        require(_tradeFee <= FEE_DENOMINATOR, "Trade fee must be less than or equal to 100%");
+        require(reserveIn > 0 && reserveOut > 0, "Reserves must be greater than 0");
+
+        // Calculate fee
+        fee = mulDiv(amountIn, _tradeFee, FEE_DENOMINATOR);
+
+        // Calculate amountInWithFee
+        uint256 amountInWithFee = amountIn - fee;
+
+        // Calculate numerator and denominator
+        uint256 numerator = mulDiv(amountInWithFee, reserveOut, 1);
+        uint256 denominator = reserveIn * FEE_DENOMINATOR + amountInWithFee;
+
+        require(denominator > 0, "Denominator must be greater than 0");
+
+        // Calculate amountOut
+        amountOut = mulDiv(numerator, FEE_DENOMINATOR, denominator);
+
+        return (amountOut, fee);
     }
 
-    function calculatePurchaseTokenOut(
-        uint256 amountETHIn
-    ) public view returns (uint256, uint256) {
-        uint256 tokenSupply = launchboxErc20Balance;
-        return
-            getAmountOutWithFee(
-                amountETHIn,
-                ethBalance + V_ETH_BALANCE,
-                tokenSupply,
-                tradeFee
-            );
+    // Helper function for safe multiplication and division
+    function mulDiv(uint256 x, uint256 y, uint256 denominator) internal pure returns (uint256 result) {
+        uint256 prod0;
+        uint256 prod1;
+        assembly {
+            let mm := mulmod(x, y, not(0))
+            prod0 := mul(x, y)
+            prod1 := sub(sub(mm, prod0), lt(mm, prod0))
+        }
+
+        if (prod1 == 0) {
+            require(denominator > 0);
+            assembly {
+                result := div(prod0, denominator)
+            }
+            return result;
+        }
+
+        require(denominator > prod1);
+
+        uint256 remainder;
+        assembly {
+            remainder := mulmod(x, y, denominator)
+        }
+        assembly {
+            prod1 := sub(prod1, gt(remainder, prod0))
+            prod0 := sub(prod0, remainder)
+        }
+
+        uint256 twos = denominator & (~denominator + 1);
+        assembly {
+            denominator := div(denominator, twos)
+        }
+
+        assembly {
+            prod0 := div(prod0, twos)
+        }
+        assembly {
+            twos := add(div(sub(0, twos), twos), 1)
+        }
+        prod0 |= prod1 * twos;
+
+        uint256 inv = (3 * denominator) ^ 2;
+        inv *= 2 - denominator * inv;
+        inv *= 2 - denominator * inv;
+        inv *= 2 - denominator * inv;
+        inv *= 2 - denominator * inv;
+        inv *= 2 - denominator * inv;
+        inv *= 2 - denominator * inv;
+
+        result = prod0 * inv;
+        return result;
     }
 
-    function calculateSaleTokenOut(
-        uint256 amountTokenIn
-    ) public view returns (uint256, uint256) {
+    function calculatePurchaseTokenOut(uint256 amountETHIn) public view returns (uint256, uint256) {
         uint256 tokenSupply = launchboxErc20Balance;
-        return
-            getAmountOutWithFee(
-                amountTokenIn,
-                tokenSupply,
-                ethBalance + V_ETH_BALANCE,
-                tradeFee
-            );
+        return getAmountOutWithFee(amountETHIn, ethBalance + V_ETH_BALANCE, tokenSupply, tradeFee);
+    }
+
+    function calculateSaleTokenOut(uint256 amountTokenIn) public view returns (uint256, uint256) {
+        uint256 tokenSupply = launchboxErc20Balance;
+        return getAmountOutWithFee(amountTokenIn, tokenSupply, ethBalance + V_ETH_BALANCE, tradeFee);
     }
 
     function _buy(uint256 ethAmount, address receiver) internal {
         // calculate tokens to mint and fee in eth
-        (uint256 tokensToMint, uint256 feeInEth) = calculatePurchaseTokenOut(
-            ethAmount
-        );
+        (uint256 tokensToMint, uint256 feeInEth) = calculatePurchaseTokenOut(ethAmount);
         if (tokensToMint > launchboxErc20Balance) {
             revert PurchaseExceedsSupply();
         }
         if (feeInEth > 0) {
-            (bool success, ) = feeReceiver.call{value: feeInEth}("");
+            (bool success,) = feeReceiver.call{value: feeInEth}("");
             if (!success) {
                 revert FeeTransferFailed();
             }
@@ -196,15 +236,10 @@ contract LaunchboxExchange {
 
     function _sell(uint256 tokenAmount, address receiver) internal {
         // calculate eth to refund and fee in token
-        (uint256 ethToReturn, uint256 feeInToken) = calculateSaleTokenOut(
-            tokenAmount
-        );
+        (uint256 ethToReturn, uint256 feeInToken) = calculateSaleTokenOut(tokenAmount);
         ethBalance -= ethToReturn;
         launchboxErc20Balance += (tokenAmount - feeInToken);
-        require(
-            token.transferFrom(receiver, address(this), tokenAmount),
-            "Transfer failed"
-        );
+        require(token.transferFrom(receiver, address(this), tokenAmount), "Transfer failed");
         if (feeInToken > 0) {
             token.transfer(feeReceiver, feeInToken);
         }
@@ -220,8 +255,7 @@ contract LaunchboxExchange {
         uint256 spotPrice = _getSpotPrice();
         uint256 wethPrice = _getWETHPrice();
         if (spotPrice > 10 ** 45) {
-            return
-                maxSupply * (((spotPrice / 10 ** 18) * wethPrice) / 10 ** 18);
+            return maxSupply * (((spotPrice / 10 ** 18) * wethPrice) / 10 ** 18);
         }
         return (maxSupply * ((spotPrice * wethPrice) / 10 ** 18)) / 10 ** 18;
     }
@@ -235,8 +269,7 @@ contract LaunchboxExchange {
     }
 
     function _getWETHPrice() internal view returns (uint256) {
-        (uint256 _WETH_RESERVE, uint256 _USDC_RESERVE, ) = WETH_USDC_PAIR
-            .getReserves();
+        (uint256 _WETH_RESERVE, uint256 _USDC_RESERVE,) = WETH_USDC_PAIR.getReserves();
         uint256 price = (_USDC_RESERVE * 10 ** 12 * 10 ** 18) / _WETH_RESERVE;
         return price;
     }

--- a/test/unit/LaunchboxExchangeUnit.t.sol
+++ b/test/unit/LaunchboxExchangeUnit.t.sol
@@ -68,14 +68,14 @@ contract LaunchboxExchangeUnit_Fork is LaunchboxExchangeBase {
         assertEq(exchange.saleActive(), true);
         assertEq(address(exchange.aerodromeRouter()), router);
     }
-    
+
     function test_initializeWithInitialBuyWithLowEth() public {
         LaunchboxExchange exchangeImpl = new LaunchboxExchange();
         exchange = LaunchboxExchange(payable(Clones.clone(address(exchangeImpl))));
         erc20.mint(address(exchange), totalToBeSold);
         erc20.mint(protocol, platformFee);
         erc20.mint(community, communityShare);
-        (uint256 tokenAmountOut, uint256 fee) = getAmountOutWithFee(1e10,1.5 ether, totalToBeSold, tradeFee);
+        (uint256 tokenAmountOut, uint256 fee) = getAmountOutWithFee(1e10, 1.5 ether, totalToBeSold, tradeFee);
         exchange.initialize{value: 1e10}(address(erc20), feeReceiver, tradeFee, maxSupply, marketCapThreshold, router);
         assertEq(address(exchange.token()), address(erc20));
         assertEq(exchange.maxSupply(), maxSupply);
@@ -132,19 +132,19 @@ contract LaunchboxExchangeUnit_Fork is LaunchboxExchangeBase {
     function test_buy_fuzz(uint256 _ethAmount) public {
         // no one in right mind will invest more than 10^45 ETH.
         // the whole world GDP is at 29 Billion ETH, which is 1.9 * 10 ^ 10.
-        _ethAmount = bound(_ethAmount, 1, 10**45);
+        _ethAmount = bound(_ethAmount, 1, 10 ** 45);
         vm.deal(address(this), _ethAmount);
         exchange.buyTokens{value: _ethAmount}();
     }
 
     function test_buy_MaxValue() public {
-        vm.deal(address(this), 10**45);
-        exchange.buyTokens{value: 10**45}();
+        vm.deal(address(this), 10 ** 45);
+        exchange.buyTokens{value: 10 ** 45}();
     }
 
     function test_sell_maxValue() public {
-        vm.deal(address(this), 10**45);
-        exchange.buyTokens{value: 10**45}();
+        vm.deal(address(this), 10 ** 45);
+        exchange.buyTokens{value: 10 ** 45}();
         uint256 balance = erc20.balanceOf(address(this));
         vm.expectRevert(LaunchboxExchange.ExchangeInactive.selector);
         exchange.sellTokens(balance);
@@ -165,19 +165,19 @@ contract LaunchboxExchangeUnit_Fork is LaunchboxExchangeBase {
         assertEq(erc20.balanceOf(address(this)), 0);
     }
 
-    function test_sell_fuzz(uint256 _ethAmount,uint256 _tokenSellAmount) public {
-        _ethAmount = bound(_ethAmount, 1, 10**45);
-        _tokenSellAmount = bound(_tokenSellAmount, 1, 10**45);
+    function test_sell_fuzz(uint256 _ethAmount, uint256 _tokenSellAmount) public {
+        _ethAmount = bound(_ethAmount, 1, 10 ** 45);
+        _tokenSellAmount = bound(_tokenSellAmount, 1, 10 ** 45);
         vm.deal(address(this), _ethAmount);
         exchange.buyTokens{value: _ethAmount}();
 
         // sell
         erc20.approve(address(exchange), _tokenSellAmount);
-        if(exchange.marketCap() > marketCapThreshold) {
+        if (exchange.marketCap() > marketCapThreshold) {
             vm.expectRevert(LaunchboxExchange.ExchangeInactive.selector);
             exchange.sellTokens(_tokenSellAmount);
         } else {
-            if(_tokenSellAmount > erc20.balanceOf(address(this))) {
+            if (_tokenSellAmount > erc20.balanceOf(address(this))) {
                 vm.expectRevert();
             }
             exchange.sellTokens(_tokenSellAmount);

--- a/test/unit/LaunchboxExchangeUnit.t.sol
+++ b/test/unit/LaunchboxExchangeUnit.t.sol
@@ -74,7 +74,7 @@ contract LaunchboxExchangeUnit_Fork is LaunchboxExchangeBase {
     }
 
     function test_tokenPriceinETH() public {
-        assertEq(exchange.getTokenPriceinETH(), (1.5 ether) * 10 ** 18 / totalToBeSold);
+        assertEq(exchange.getTokenPriceinETH(), ((1.5 ether) * 10 ** 18) / totalToBeSold);
     }
 
     function test_buy() public {


### PR DESCRIPTION
## Description

This PR addresses issues in the LaunchboxExchange contract focusing on preventing arithmetic overflow in the `getAmountOutWithFee` function.

### Changes

1. Updated `getAmountOutWithFee` function
- Changed fee representation to basis points (1/10000) for more precise fee settings.
- Implemented a safe `mulDiv` function to prevent overflow in calculations.
- Updated input validation for trade fee.

2. Constants and state variables
- Added `FEE_DENOMINATOR` constant set to 10000.

### Rationale
The previous implementation was susceptible to arithmetic overflow, especially with high fee values. The new implementation uses a more robust calculation method and allows for more precise fee settings.

### Impact

- `tradeFee` is now represented in basis points. Existing fee values need to be updated accordingly (e.g., 10% fee should now be set to 1000).
- The contract can now handle higher fee values without overflow issues.