### PR TITLE
Implemented fallback mechanism, if chainlink price is stale + fixed compilation error

### DIFF
--- a/src/launchbox/token/LaunchboxFactory.sol
+++ b/src/launchbox/token/LaunchboxFactory.sol
@@ -8,7 +8,7 @@ import {LaunchboxERC20} from "./LaunchboxERC20.sol";
 contract LaunchboxFactory is Ownable(msg.sender) {
     event TokenDeployed(address tokenAddress, address launchboxExchangeAddress, address creator);
     event PlatformFeePercentageUpdated(uint256 newPlatformFee);
-    event CommunityPerecentageUpdated(uint256 newCommunityShare);
+    event CommunityPercentageUpdated(uint256 newCommunityShare);
     event PlatformFeeAddressUpdated(address newPlatformFeeReceiver);
     event MarketCapThresholdUpdated(uint256 newMarketCapThreshold);
     event TradeFeeUpdated(uint256 newTradeFee);
@@ -124,9 +124,9 @@ contract LaunchboxFactory is Ownable(msg.sender) {
         emit TradeFeeUpdated(_tradeFee);
     }
 
-    function setCommunityPerecentage(uint256 _communityPercentage) public onlyOwner {
+    function setCommunityPercentage(uint256 _communityPercentage) public onlyOwner {
         communityPercentage = _communityPercentage;
-        emit CommunityPerecentageUpdated(_communityPercentage);
+        emit CommunityPercentageUpdated(_communityPercentage);
     }
 
     function setPlatformFeeAddress(address payable _platformFeeAddress) public onlyOwner {

--- a/test/unit/LaunchboxFactoryUnit.t.sol
+++ b/test/unit/LaunchboxFactoryUnit.t.sol
@@ -115,14 +115,14 @@ contract LaunchboxFactoryUnit_Fork is LaunchboxFactoryBase {
     }
 
     function test_setCommunityFee() public {
-        launchpad.setCommunityPerecentage(1);
+        launchpad.setCommunityPercentage(1);
         assertEq(launchpad.communityPercentage(), 1);
     }
 
     function test_revert_setCommunityFeeNonOwner() public {
         vm.prank(makeAddr("unknown"));
         vm.expectRevert();
-        launchpad.setCommunityPerecentage(1);
+        launchpad.setCommunityPercentage(1);
         assertEq(launchpad.communityPercentage(), communityPercentage);
     }
 


### PR DESCRIPTION
1. This PR fixes a compilation error due to _getETHPrice() returning an int256

2. In case of a stale chainlink price, a fallback mechanism is used so that token purchase functionality is still available